### PR TITLE
[homekit] Simplify accessory discovery

### DIFF
--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/discovery/HomekitChildDiscoveryService.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/discovery/HomekitChildDiscoveryService.java
@@ -15,13 +15,12 @@ package org.openhab.binding.homekit.internal.discovery;
 import static org.openhab.binding.homekit.internal.HomekitBindingConstants.*;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.homekit.internal.dto.Accessory;
 import org.openhab.binding.homekit.internal.handler.HomekitBridgeHandler;
-import org.openhab.core.config.discovery.AbstractDiscoveryService;
+import org.openhab.core.config.discovery.AbstractThingHandlerDiscoveryService;
 import org.openhab.core.config.discovery.DiscoveryResultBuilder;
 import org.openhab.core.config.discovery.DiscoveryService;
 import org.openhab.core.thing.Thing;
@@ -36,30 +35,17 @@ import org.osgi.service.component.annotations.Component;
  */
 @NonNullByDefault
 @Component(service = DiscoveryService.class)
-public class HomekitChildDiscoveryService extends AbstractDiscoveryService {
+public class HomekitChildDiscoveryService extends AbstractThingHandlerDiscoveryService<HomekitBridgeHandler> {
 
     private static final int TIMEOUT_SECONDS = 10;
 
-    private final Set<HomekitBridgeHandler> bridgeHandlers = new HashSet<>();
-
     public HomekitChildDiscoveryService() {
-        super(Set.of(THING_TYPE_ACCESSORY), TIMEOUT_SECONDS);
-    }
-
-    public void addBridgeHandler(HomekitBridgeHandler handler) {
-        bridgeHandlers.add(handler);
-        startScan();
-    }
-
-    public void removeBridgeHandler(HomekitBridgeHandler handler) {
-        bridgeHandlers.remove(handler);
+        super(HomekitBridgeHandler.class, Set.of(THING_TYPE_ACCESSORY), TIMEOUT_SECONDS);
     }
 
     @Override
-    protected void startScan() {
-        for (HomekitBridgeHandler handler : bridgeHandlers) {
-            discoverChildren(handler.getThing(), handler.getAccessories());
-        }
+    public void startScan() {
+        discoverChildren(thingHandler.getThing(), thingHandler.getAccessories());
     }
 
     private void discoverChildren(Thing bridge, Collection<Accessory> accessories) {

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBridgeHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBridgeHandler.java
@@ -14,6 +14,9 @@ package org.openhab.binding.homekit.internal.handler;
 
 import static org.openhab.binding.homekit.internal.HomekitBindingConstants.FAKE_PROPERTY_CHANNEL_TYPE_UID;
 
+import java.util.Collection;
+import java.util.Set;
+
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.binding.homekit.internal.discovery.HomekitChildDiscoveryService;
 import org.openhab.binding.homekit.internal.dto.Accessory;
@@ -27,6 +30,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.binding.BridgeHandler;
 import org.openhab.core.thing.binding.ThingHandler;
+import org.openhab.core.thing.binding.ThingHandlerService;
 import org.openhab.core.thing.binding.builder.BridgeBuilder;
 import org.openhab.core.thing.type.ChannelDefinition;
 import org.openhab.core.types.Command;
@@ -47,12 +51,9 @@ import org.slf4j.LoggerFactory;
 public class HomekitBridgeHandler extends HomekitBaseAccessoryHandler implements BridgeHandler {
 
     private final Logger logger = LoggerFactory.getLogger(HomekitBridgeHandler.class);
-    private final HomekitChildDiscoveryService discoveryService;
 
-    public HomekitBridgeHandler(Bridge bridge, HomekitTypeProvider typeProvider,
-            HomekitChildDiscoveryService discoveryService, HomekitKeyStore keyStore) {
+    public HomekitBridgeHandler(Bridge bridge, HomekitTypeProvider typeProvider, HomekitKeyStore keyStore) {
         super(bridge, typeProvider, keyStore);
-        this.discoveryService = discoveryService;
     }
 
     @Override
@@ -92,7 +93,6 @@ public class HomekitBridgeHandler extends HomekitBaseAccessoryHandler implements
     @Override
     protected void accessoriesLoaded() {
         logger.debug("Bridge accessories loaded {}", accessories.size());
-        discoveryService.addBridgeHandler(this); // discover child accessories
         createProperties(); // create properties from accessory information
     }
 
@@ -102,9 +102,8 @@ public class HomekitBridgeHandler extends HomekitBaseAccessoryHandler implements
     }
 
     @Override
-    public void dispose() {
-        discoveryService.removeBridgeHandler(this);
-        super.dispose();
+    public Collection<Class<? extends ThingHandlerService>> getServices() {
+        return Set.of(HomekitChildDiscoveryService.class);
     }
 
     /**


### PR DESCRIPTION
This is a suggestion for simplifying the discovery by utilizing `AbstractThingHandlerDiscoveryService` for handler injection.