### PR TITLE
[homekit] Add support for manual configuration

### DIFF
--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/HomekitBindingConstants.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/HomekitBindingConstants.java
@@ -47,9 +47,9 @@ public class HomekitBindingConstants {
     // configuration parameters
     public static final String CONFIG_HOST = "host";
     public static final String CONFIG_REFRESH_INTERVAL = "refreshInterval";
+    public static final String CONFIG_ACCESSORY_ID = "accessoryID";
 
     // thing properties
-    public static final String PROPERTY_ACCESSORY_UID = "accessoryUID";
     public static final String PROPERTY_PROTOCOL_VERSION = "protocolVersion";
     public static final String PROPERTY_ACCESSORY_CATEGORY = "accessoryCategory";
 

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/discovery/HomekitChildDiscoveryService.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/discovery/HomekitChildDiscoveryService.java
@@ -59,8 +59,9 @@ public class HomekitChildDiscoveryService extends AbstractThingHandlerDiscoveryS
                         .withBridge(bridge.getUID()) //
                         .withLabel(THING_LABEL_FMT.formatted(thingLabel, bridge.getLabel())) //
                         .withProperty(CONFIG_HOST, "n/a") //
-                        .withProperty(PROPERTY_ACCESSORY_UID, uid.toString()) //
-                        .withRepresentationProperty(PROPERTY_ACCESSORY_UID).build());
+                        .withProperty(Thing.PROPERTY_MAC_ADDRESS, "n/a") //
+                        .withProperty(CONFIG_ACCESSORY_ID, aid.toString()) //
+                        .withRepresentationProperty(CONFIG_ACCESSORY_ID).build());
             }
         });
     }

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/discovery/HomekitMdnsDiscoveryParticipant.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/discovery/HomekitMdnsDiscoveryParticipant.java
@@ -89,7 +89,7 @@ public class HomekitMdnsDiscoveryParticipant implements MDNSDiscoveryParticipant
                         .withProperty(CONFIG_HOST, host) //
                         .withProperty(Thing.PROPERTY_MAC_ADDRESS, mac) //
                         .withProperty(PROPERTY_ACCESSORY_CATEGORY, category.toString()) //
-                        .withProperty(PROPERTY_ACCESSORY_UID, new ThingUID(THING_TYPE_ACCESSORY, "1").toString()) //
+                        .withProperty(CONFIG_ACCESSORY_ID, "1".toString()) //
                         .withRepresentationProperty(Thing.PROPERTY_MAC_ADDRESS);
 
                 if (properties.get("md") instanceof String model) {

--- a/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
+++ b/bundles/org.openhab.binding.homekit/src/main/java/org/openhab/binding/homekit/internal/handler/HomekitBaseAccessoryHandler.java
@@ -15,6 +15,7 @@ package org.openhab.binding.homekit.internal.handler;
 import static org.openhab.binding.homekit.internal.HomekitBindingConstants.*;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
@@ -55,7 +56,6 @@ import org.openhab.core.thing.Bridge;
 import org.openhab.core.thing.Thing;
 import org.openhab.core.thing.ThingStatus;
 import org.openhab.core.thing.ThingStatusDetail;
-import org.openhab.core.thing.ThingUID;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.binding.ThingHandlerService;
 import org.openhab.core.thing.type.ChannelDefinition;
@@ -176,14 +176,14 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
     protected abstract void accessoriesLoaded();
 
     /**
-     * Extracts the accessory ID from the 'Accessory UID' property.
+     * Returns the accessory ID from the 'AccessoryID' configuration parameter.
      *
      * @return the accessory ID, or null if it cannot be determined
      */
     protected @Nullable Integer getAccessoryId() {
-        if (thing.getProperties().get(PROPERTY_ACCESSORY_UID) instanceof String accessoryUid) {
+        if (getConfig().get(CONFIG_ACCESSORY_ID) instanceof BigDecimal accessoryId) {
             try {
-                return Integer.parseInt(new ThingUID(accessoryUid).getId());
+                return accessoryId.intValue();
             } catch (NumberFormatException e) {
             }
         }
@@ -367,10 +367,10 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
     }
 
     private @Nullable String checkedMacAddress() {
-        String macAddress = getThing().getProperties().get(Thing.PROPERTY_MAC_ADDRESS);
-        if (macAddress == null) {
+        if (!(getConfig().get(Thing.PROPERTY_MAC_ADDRESS) instanceof String macAddress) || macAddress.isBlank()) {
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR,
                     i18nProvider.getText(bundle, "error.missing-mac-address", "Missing MAC address", null));
+            return null;
         }
         return macAddress;
     }
@@ -458,9 +458,9 @@ public abstract class HomekitBaseAccessoryHandler extends BaseThingHandler imple
             logger.warn("Cannot unpair child accessory '{}'", thing.getUID());
             return false;
         }
-        String macAddress = getThing().getProperties().get(Thing.PROPERTY_MAC_ADDRESS);
-        if (macAddress == null) {
-            logger.warn("Cannot unpair accessory '{}' due to missing mac address property", thing.getUID());
+
+        if (!(getConfig().get(Thing.PROPERTY_MAC_ADDRESS) instanceof String macAddress) || macAddress.isBlank()) {
+            logger.warn("Cannot unpair accessory '{}' due to missing mac address configuration", thing.getUID());
             return false;
         }
         try {

--- a/bundles/org.openhab.binding.homekit/src/main/resources/OH-INF/i18n/homekit.properties
+++ b/bundles/org.openhab.binding.homekit/src/main/resources/OH-INF/i18n/homekit.properties
@@ -12,12 +12,20 @@ thing-type.homekit.bridge.description = HomeKit Accessory Bridge
 
 # thing types config
 
+thing-type.config.homekit.accessory.accessoryID.label = Accessory ID
+thing-type.config.homekit.accessory.accessoryID.description = ID of the accessory.
 thing-type.config.homekit.accessory.host.label = IP Address
 thing-type.config.homekit.accessory.host.description = IP v4 address of the HomeKit accessory.
+thing-type.config.homekit.accessory.macAddress.label = MAC Address
+thing-type.config.homekit.accessory.macAddress.description = Unique accessory identifier.
 thing-type.config.homekit.accessory.refreshInterval.label = Refresh Interval
 thing-type.config.homekit.accessory.refreshInterval.description = Interval at which the accessory is polled in sec.
+thing-type.config.homekit.bridge.accessoryID.label = Accessory ID
+thing-type.config.homekit.bridge.accessoryID.description = ID of the accessory.
 thing-type.config.homekit.bridge.host.label = IP Address
 thing-type.config.homekit.bridge.host.description = IP v4 address of the HomeKit bridge.
+thing-type.config.homekit.bridge.macAddress.label = MAC Address
+thing-type.config.homekit.bridge.macAddress.description = Unique accessory identifier.
 
 # thing error state messages
 

--- a/bundles/org.openhab.binding.homekit/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.homekit/src/main/resources/OH-INF/thing/thing-types.xml
@@ -13,6 +13,16 @@
 				<label>IP Address</label>
 				<description>IP v4 address of the HomeKit accessory.</description>
 			</parameter>
+			<parameter name="macAddress" type="text" required="true">
+				<label>MAC Address</label>
+				<description>Unique accessory identifier.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="accessoryID" type="integer" required="true">
+				<label>Accessory ID</label>
+				<description>ID of the accessory.</description>
+				<advanced>true</advanced>
+			</parameter>
 			<parameter name="refreshInterval" type="integer" unit="s" min="10" required="false">
 				<label>Refresh Interval</label>
 				<description>Interval at which the accessory is polled in sec.</description>
@@ -31,6 +41,16 @@
 				<context>network-address</context>
 				<label>IP Address</label>
 				<description>IP v4 address of the HomeKit bridge.</description>
+			</parameter>
+			<parameter name="macAddress" type="text" required="true">
+				<label>MAC Address</label>
+				<description>Unique accessory identifier.</description>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="accessoryID" type="integer" required="true">
+				<label>Accessory ID</label>
+				<description>ID of the accessory.</description>
+				<advanced>true</advanced>
 			</parameter>
 		</config-description>
 	</bridge-type>


### PR DESCRIPTION
This is literally all it takes to support manual configuration (UI/DSL/YAML). This is an MVP implementation:
- Property `accessoryUID` replaced by configuration parameter `accessoryID`. It's now a simple integer value without any ThingID/BridgeID mixed in, thus also renamed to remove the **U**.
- Property `macAddress` replaced by configuration parameter `macAddress`.

A few additional notes:
- When the bridge is created through mDNS discovery, the parameters will be automatically updated. See openhab/openhab-core#5093. To be clear, if the macAddress or accessoryID would be removed or trashed, it will automatically be restored to discovered values.
- The name of `macAddress` could be reconsidered. AI gave me the comment: "Although the id resembles a MAC address format, it’s just a unique accessory identifier that must be stable and unique per accessory". I have now yet verified if this is true.

This configuration now works for me:
```java
Bridge homekit:bridge:velux "VELUX Gateway" [ host="192.168.0.235:5001", macAddress="XX:XX:XX:XX:XX:XX", accessoryID=1 ] {
    Thing accessory 2 "VELUX Sensor" @ "Hallway" [ host="n/a", accessoryID=2 ]
    Thing accessory 3 "VELUX Window" @ "Hallway" [ host="n/a", accessoryID=3 ]
    Thing accessory 4 "VELUX Window" @ "Small bathroom" [ host="n/a", accessoryID=4 ]
}
```